### PR TITLE
allow host to add, remove, and reorder rounds in lobby

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.5.16",
     "apollo-link-ws": "^1.0.19",
+    "array-move": "^2.2.1",
     "date-fns": "^2.11.1",
     "dotenv": "^8.2.0",
     "graphql": "^14.6.0",
@@ -58,6 +59,7 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.3",
-    "@types/uuid": "^7.0.2"
+    "@types/uuid": "^7.0.2",
+    "@types/array-move": "^2.0.0"
   }
 }

--- a/app/src/components/PlayerChip.tsx
+++ b/app/src/components/PlayerChip.tsx
@@ -16,7 +16,7 @@ function PlayerChip(props: {
         props.handleSwitch && (
           <LoopIcon
             style={{
-              color: grey[500],
+              color: grey[600],
               backgroundColor: "transparent",
               cursor: "pointer"
             }}

--- a/app/src/components/RoundSettingsList.tsx
+++ b/app/src/components/RoundSettingsList.tsx
@@ -1,0 +1,21 @@
+import { List } from "@material-ui/core"
+import { grey } from "@material-ui/core/colors"
+import * as React from "react"
+
+function RoundSettingsList(props: { children: React.ReactNode }) {
+  return (
+    <List
+      style={{
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "rgba(0, 0, 0, 0.23)",
+        borderRadius: 4,
+        color: grey[500]
+      }}
+    >
+      {props.children}
+    </List>
+  )
+}
+
+export default RoundSettingsList

--- a/app/src/components/RoundSettingsList.tsx
+++ b/app/src/components/RoundSettingsList.tsx
@@ -10,7 +10,7 @@ function RoundSettingsList(props: { children: React.ReactNode }) {
         borderStyle: "solid",
         borderColor: "rgba(0, 0, 0, 0.23)",
         borderRadius: 4,
-        color: grey[500]
+        color: grey[600]
       }}
     >
       {props.children}

--- a/app/src/generated/graphql.schema.json
+++ b/app/src/generated/graphql.schema.json
@@ -12225,6 +12225,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "rounds_game_id_order_sequence_key",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "rounds_pkey",
             "description": "",
             "isDeprecated": false,

--- a/app/src/generated/graphql.tsx
+++ b/app/src/generated/graphql.tsx
@@ -2239,6 +2239,31 @@ export type RemovePlayerMutationVariables = {
 
 export type RemovePlayerMutation = { delete_players_by_pk?: Maybe<Pick<Players, 'id'>> };
 
+export type DeleteRoundMutationVariables = {
+  id: Scalars['uuid'];
+};
+
+
+export type DeleteRoundMutation = { delete_rounds_by_pk?: Maybe<Pick<Rounds, 'id'>> };
+
+export type UpdateAllRoundsMutationVariables = {
+  gameId: Scalars['uuid'];
+  rounds: Array<RoundsInsertInput>;
+};
+
+
+export type UpdateAllRoundsMutation = { insert_games_one?: Maybe<(
+    Pick<Games, 'id'>
+    & { rounds: Array<Pick<Rounds, 'id' | 'order_sequence'>> }
+  )> };
+
+export type AddRoundMutationVariables = {
+  object: RoundsInsertInput;
+};
+
+
+export type AddRoundMutation = { insert_rounds_one?: Maybe<Pick<Rounds, 'id' | 'value' | 'order_sequence'>> };
+
 export type CreateTurnMutationVariables = {
   gameId: Scalars['uuid'];
   playerId: Scalars['uuid'];
@@ -2790,6 +2815,109 @@ export function useRemovePlayerMutation(baseOptions?: ApolloReactHooks.MutationH
 export type RemovePlayerMutationHookResult = ReturnType<typeof useRemovePlayerMutation>;
 export type RemovePlayerMutationResult = ApolloReactCommon.MutationResult<RemovePlayerMutation>;
 export type RemovePlayerMutationOptions = ApolloReactCommon.BaseMutationOptions<RemovePlayerMutation, RemovePlayerMutationVariables>;
+export const DeleteRoundDocument = gql`
+    mutation DeleteRound($id: uuid!) {
+  delete_rounds_by_pk(id: $id) {
+    id
+  }
+}
+    `;
+export type DeleteRoundMutationFn = ApolloReactCommon.MutationFunction<DeleteRoundMutation, DeleteRoundMutationVariables>;
+
+/**
+ * __useDeleteRoundMutation__
+ *
+ * To run a mutation, you first call `useDeleteRoundMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteRoundMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteRoundMutation, { data, loading, error }] = useDeleteRoundMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useDeleteRoundMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteRoundMutation, DeleteRoundMutationVariables>) {
+        return ApolloReactHooks.useMutation<DeleteRoundMutation, DeleteRoundMutationVariables>(DeleteRoundDocument, baseOptions);
+      }
+export type DeleteRoundMutationHookResult = ReturnType<typeof useDeleteRoundMutation>;
+export type DeleteRoundMutationResult = ApolloReactCommon.MutationResult<DeleteRoundMutation>;
+export type DeleteRoundMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteRoundMutation, DeleteRoundMutationVariables>;
+export const UpdateAllRoundsDocument = gql`
+    mutation UpdateAllRounds($gameId: uuid!, $rounds: [rounds_insert_input!]!) {
+  insert_games_one(object: {id: $gameId, rounds: {data: $rounds, on_conflict: {constraint: rounds_pkey, update_columns: [order_sequence]}}}, on_conflict: {constraint: games_pkey, update_columns: [id]}) {
+    id
+    rounds {
+      id
+      order_sequence
+    }
+  }
+}
+    `;
+export type UpdateAllRoundsMutationFn = ApolloReactCommon.MutationFunction<UpdateAllRoundsMutation, UpdateAllRoundsMutationVariables>;
+
+/**
+ * __useUpdateAllRoundsMutation__
+ *
+ * To run a mutation, you first call `useUpdateAllRoundsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateAllRoundsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateAllRoundsMutation, { data, loading, error }] = useUpdateAllRoundsMutation({
+ *   variables: {
+ *      gameId: // value for 'gameId'
+ *      rounds: // value for 'rounds'
+ *   },
+ * });
+ */
+export function useUpdateAllRoundsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateAllRoundsMutation, UpdateAllRoundsMutationVariables>) {
+        return ApolloReactHooks.useMutation<UpdateAllRoundsMutation, UpdateAllRoundsMutationVariables>(UpdateAllRoundsDocument, baseOptions);
+      }
+export type UpdateAllRoundsMutationHookResult = ReturnType<typeof useUpdateAllRoundsMutation>;
+export type UpdateAllRoundsMutationResult = ApolloReactCommon.MutationResult<UpdateAllRoundsMutation>;
+export type UpdateAllRoundsMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateAllRoundsMutation, UpdateAllRoundsMutationVariables>;
+export const AddRoundDocument = gql`
+    mutation AddRound($object: rounds_insert_input!) {
+  insert_rounds_one(object: $object) {
+    id
+    value
+    order_sequence
+  }
+}
+    `;
+export type AddRoundMutationFn = ApolloReactCommon.MutationFunction<AddRoundMutation, AddRoundMutationVariables>;
+
+/**
+ * __useAddRoundMutation__
+ *
+ * To run a mutation, you first call `useAddRoundMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddRoundMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addRoundMutation, { data, loading, error }] = useAddRoundMutation({
+ *   variables: {
+ *      object: // value for 'object'
+ *   },
+ * });
+ */
+export function useAddRoundMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddRoundMutation, AddRoundMutationVariables>) {
+        return ApolloReactHooks.useMutation<AddRoundMutation, AddRoundMutationVariables>(AddRoundDocument, baseOptions);
+      }
+export type AddRoundMutationHookResult = ReturnType<typeof useAddRoundMutation>;
+export type AddRoundMutationResult = ApolloReactCommon.MutationResult<AddRoundMutation>;
+export type AddRoundMutationOptions = ApolloReactCommon.BaseMutationOptions<AddRoundMutation, AddRoundMutationVariables>;
 export const CreateTurnDocument = gql`
     mutation CreateTurn($gameId: uuid!, $playerId: uuid!) {
   insert_turns_one(object: {game_id: $gameId, player_id: $playerId}) {

--- a/app/src/generated/graphql.tsx
+++ b/app/src/generated/graphql.tsx
@@ -2241,10 +2241,15 @@ export type RemovePlayerMutation = { delete_players_by_pk?: Maybe<Pick<Players, 
 
 export type DeleteRoundMutationVariables = {
   id: Scalars['uuid'];
+  gameId: Scalars['uuid'];
+  rounds: Array<RoundsInsertInput>;
 };
 
 
-export type DeleteRoundMutation = { delete_rounds_by_pk?: Maybe<Pick<Rounds, 'id'>> };
+export type DeleteRoundMutation = { delete_rounds_by_pk?: Maybe<Pick<Rounds, 'id'>>, insert_games_one?: Maybe<(
+    Pick<Games, 'id'>
+    & { rounds: Array<Pick<Rounds, 'id' | 'order_sequence'>> }
+  )> };
 
 export type UpdateAllRoundsMutationVariables = {
   gameId: Scalars['uuid'];
@@ -2816,9 +2821,16 @@ export type RemovePlayerMutationHookResult = ReturnType<typeof useRemovePlayerMu
 export type RemovePlayerMutationResult = ApolloReactCommon.MutationResult<RemovePlayerMutation>;
 export type RemovePlayerMutationOptions = ApolloReactCommon.BaseMutationOptions<RemovePlayerMutation, RemovePlayerMutationVariables>;
 export const DeleteRoundDocument = gql`
-    mutation DeleteRound($id: uuid!) {
+    mutation DeleteRound($id: uuid!, $gameId: uuid!, $rounds: [rounds_insert_input!]!) {
   delete_rounds_by_pk(id: $id) {
     id
+  }
+  insert_games_one(object: {id: $gameId, rounds: {data: $rounds, on_conflict: {constraint: rounds_pkey, update_columns: [order_sequence]}}}, on_conflict: {constraint: games_pkey, update_columns: [id]}) {
+    id
+    rounds {
+      id
+      order_sequence
+    }
   }
 }
     `;
@@ -2838,6 +2850,8 @@ export type DeleteRoundMutationFn = ApolloReactCommon.MutationFunction<DeleteRou
  * const [deleteRoundMutation, { data, loading, error }] = useDeleteRoundMutation({
  *   variables: {
  *      id: // value for 'id'
+ *      gameId: // value for 'gameId'
+ *      rounds: // value for 'rounds'
  *   },
  * });
  */

--- a/app/src/pages/Lobby/ControllableRoundSettings.tsx
+++ b/app/src/pages/Lobby/ControllableRoundSettings.tsx
@@ -20,7 +20,7 @@ import {
   useDeleteRoundMutation,
   useUpdateAllRoundsMutation
 } from "generated/graphql"
-import { capitalize, lowerFirst } from "lodash"
+import { capitalize, lowerFirst, reject } from "lodash"
 import * as React from "react"
 
 function ControllableRoundSettings() {
@@ -105,10 +105,28 @@ function ControllableRoundSettings() {
               <ListItemSecondaryAction>
                 <IconButton
                   size="small"
-                  onClick={() => {
-                    deleteRound({
+                  onClick={async () => {
+                    await deleteRound({
                       variables: {
                         id: round.id
+                      }
+                    })
+                    const updatedRounds = reject(
+                      currentGame.rounds,
+                      _r => _r.id === round.id
+                    )
+                    updateAllRounds({
+                      variables: {
+                        gameId: currentGame.id,
+                        rounds: updatedRounds.map(
+                          (updatedRound, updatedIndex) => {
+                            return {
+                              id: updatedRound.id,
+                              value: updatedRound.value,
+                              order_sequence: updatedIndex
+                            }
+                          }
+                        )
                       }
                     })
                   }}

--- a/app/src/pages/Lobby/ControllableRoundSettings.tsx
+++ b/app/src/pages/Lobby/ControllableRoundSettings.tsx
@@ -106,17 +106,13 @@ function ControllableRoundSettings() {
                 <IconButton
                   size="small"
                   onClick={async () => {
-                    await deleteRound({
-                      variables: {
-                        id: round.id
-                      }
-                    })
                     const updatedRounds = reject(
                       currentGame.rounds,
                       _r => _r.id === round.id
                     )
-                    updateAllRounds({
+                    await deleteRound({
                       variables: {
+                        id: round.id,
                         gameId: currentGame.id,
                         rounds: updatedRounds.map(
                           (updatedRound, updatedIndex) => {

--- a/app/src/pages/Lobby/ControllableRoundSettings.tsx
+++ b/app/src/pages/Lobby/ControllableRoundSettings.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   IconButton,
   InputAdornment,
-  List,
   ListItem,
   ListItemIcon,
   ListItemSecondaryAction,
@@ -14,6 +13,7 @@ import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown"
 import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp"
 import CloseIcon from "@material-ui/icons/Close"
 import arrayMove from "array-move"
+import RoundSettingsList from "components/RoundSettingsList"
 import { CurrentGameContext } from "contexts/CurrentGame"
 import {
   useAddRoundMutation,
@@ -32,14 +32,7 @@ function ControllableRoundSettings() {
   const [addRoundValue, setAddRoundValue] = React.useState("")
 
   return (
-    <List
-      style={{
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderColor: "rgba(0, 0, 0, 0.23)",
-        borderRadius: 4
-      }}
-    >
+    <RoundSettingsList>
       <>
         {currentGame.rounds.map((round, index) => {
           return (
@@ -174,7 +167,7 @@ function ControllableRoundSettings() {
           </ListItemSecondaryAction>
         </ListItem>
       </>
-    </List>
+    </RoundSettingsList>
   )
 }
 

--- a/app/src/pages/Lobby/ControllableRoundSettings.tsx
+++ b/app/src/pages/Lobby/ControllableRoundSettings.tsx
@@ -36,7 +36,7 @@ function ControllableRoundSettings() {
       <>
         {currentGame.rounds.map((round, index) => {
           return (
-            <ListItem>
+            <ListItem key={round.id}>
               <ListItemIcon>
                 <>
                   <IconButton

--- a/app/src/pages/Lobby/Inputs.tsx
+++ b/app/src/pages/Lobby/Inputs.tsx
@@ -36,7 +36,7 @@ export function UsernameInput(props: {
         </Box>
         <Box pl={2}>
           <Button
-            disabled={value === "" || value.length > 15}
+            disabled={value === ""}
             variant="outlined"
             size="large"
             onClick={() => {
@@ -53,7 +53,7 @@ export function UsernameInput(props: {
         </Box>
       </Box>
       <Box pt={1} color={grey[500]}>
-        15 character limit. Emojis encouraged! 🌍🚀✨
+        Emojis encouraged! 🌍🚀✨
       </Box>
     </>
   )

--- a/app/src/pages/Lobby/Inputs.tsx
+++ b/app/src/pages/Lobby/Inputs.tsx
@@ -52,7 +52,7 @@ export function UsernameInput(props: {
           </Button>
         </Box>
       </Box>
-      <Box pt={1} color={grey[500]}>
+      <Box pt={1} color={grey[600]}>
         Emojis encouraged! 🌍🚀✨
       </Box>
     </>

--- a/app/src/pages/Lobby/RoundSettings.tsx
+++ b/app/src/pages/Lobby/RoundSettings.tsx
@@ -1,0 +1,35 @@
+import { Box, List, ListItem, ListItemText } from "@material-ui/core"
+import { grey } from "@material-ui/core/colors"
+import { CurrentGameContext } from "contexts/CurrentGame"
+import { capitalize } from "lodash"
+import * as React from "react"
+
+function RoundSettings() {
+  const currentGame = React.useContext(CurrentGameContext)
+
+  return (
+    <List
+      style={{
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "rgba(0, 0, 0, 0.23)",
+        borderRadius: 4,
+        color: grey[500]
+      }}
+    >
+      {currentGame.rounds.map((round, index) => {
+        return (
+          <ListItem>
+            <ListItemText>
+              <Box pl={2}>
+                {index + 1}. {capitalize(round.value)}
+              </Box>
+            </ListItemText>
+          </ListItem>
+        )
+      })}
+    </List>
+  )
+}
+
+export default RoundSettings

--- a/app/src/pages/Lobby/RoundSettings.tsx
+++ b/app/src/pages/Lobby/RoundSettings.tsx
@@ -1,5 +1,5 @@
-import { Box, List, ListItem, ListItemText } from "@material-ui/core"
-import { grey } from "@material-ui/core/colors"
+import { Box, ListItem, ListItemText } from "@material-ui/core"
+import RoundSettingsList from "components/RoundSettingsList"
 import { CurrentGameContext } from "contexts/CurrentGame"
 import { capitalize } from "lodash"
 import * as React from "react"
@@ -8,15 +8,7 @@ function RoundSettings() {
   const currentGame = React.useContext(CurrentGameContext)
 
   return (
-    <List
-      style={{
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderColor: "rgba(0, 0, 0, 0.23)",
-        borderRadius: 4,
-        color: grey[500]
-      }}
-    >
+    <RoundSettingsList>
       {currentGame.rounds.map((round, index) => {
         return (
           <ListItem>
@@ -28,7 +20,7 @@ function RoundSettings() {
           </ListItem>
         )
       })}
-    </List>
+    </RoundSettingsList>
   )
 }
 

--- a/app/src/pages/Lobby/RoundSettings.tsx
+++ b/app/src/pages/Lobby/RoundSettings.tsx
@@ -11,7 +11,7 @@ function RoundSettings() {
     <RoundSettingsList>
       {currentGame.rounds.map((round, index) => {
         return (
-          <ListItem>
+          <ListItem key={round.id}>
             <ListItemText>
               <Box pl={2}>
                 {index + 1}. {capitalize(round.value)}

--- a/app/src/pages/Lobby/index.tsx
+++ b/app/src/pages/Lobby/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   createStyles,
   Divider,
   Grid,
@@ -51,7 +52,7 @@ function SettingsSection() {
             Settings
           </Typography>
           {currentPlayer.role === PlayerRole.Participant && (
-            <div style={{ color: grey[500] }}>
+            <div style={{ color: grey[600] }}>
               (Only your host can set these)
             </div>
           )}
@@ -78,6 +79,10 @@ function SettingsSection() {
           <Typography variant="h6" className={titleClasses.title}>
             Rounds
           </Typography>
+          <Box pl={2} pt={1} fontSize="0.75rem" color={grey[600]}>
+            {currentPlayer.role === PlayerRole.Host &&
+              "You can add, remove, or reorder rounds. By default, cards submitted will be re-used across rounds of Taboo, Charades, and Password."}
+          </Box>
         </Grid>
         <Grid item>
           {currentPlayer.role === PlayerRole.Host ? (
@@ -86,6 +91,7 @@ function SettingsSection() {
             <RoundSettings></RoundSettings>
           )}
         </Grid>
+        <Grid item></Grid>
       </Grid>
     </Grid>
   )

--- a/app/src/pages/Lobby/index.tsx
+++ b/app/src/pages/Lobby/index.tsx
@@ -10,13 +10,14 @@ import { grey } from "@material-ui/core/colors"
 import { CurrentGameContext } from "contexts/CurrentGame"
 import { CurrentPlayerContext, PlayerRole } from "contexts/CurrentPlayer"
 import { useTitleStyle } from "index"
-import HowToPlay from "pages/Home/HowToPlay"
+import ControllableRoundSettings from "pages/Lobby/ControllableRoundSettings"
 import {
   LetterInput,
   SecondsPerTurnInput,
   SubmissionsPerPlayerInput,
   UsernameInput
 } from "pages/Lobby/Inputs"
+import RoundSettings from "pages/Lobby/RoundSettings"
 import WaitingRoom from "pages/Lobby/WaitingRoom"
 import * as React from "react"
 
@@ -30,20 +31,10 @@ const useStyles = makeStyles((theme: Theme) =>
 
 function ShareSection() {
   const currentGame = React.useContext(CurrentGameContext)
-  const titleClasses = useTitleStyle()
   return (
     <Grid item>
-      <Grid container spacing={2} direction="column">
-        <Grid item>
-          <Typography variant="h4" className={titleClasses.title}>
-            Share
-          </Typography>
-        </Grid>
-        <Grid item>
-          {`Share the code with everyone playing`}
-          <Typography variant="h6">{currentGame.join_code}</Typography>
-        </Grid>
-      </Grid>
+      {`Share the code with everyone playing`}
+      <Typography variant="h6">{currentGame.join_code}</Typography>
     </Grid>
   )
 }
@@ -71,12 +62,29 @@ function SettingsSection() {
           ></SecondsPerTurnInput>
         </Grid>
         <Grid item>
+          <Typography variant="h6" className={titleClasses.title}>
+            Cards
+          </Typography>
+        </Grid>
+        <Grid item>
           <SubmissionsPerPlayerInput
             value={String(currentGame.num_entries_per_player || "")}
           ></SubmissionsPerPlayerInput>
         </Grid>
         <Grid item>
           <LetterInput value={currentGame.starting_letter || ""}></LetterInput>
+        </Grid>
+        <Grid item>
+          <Typography variant="h6" className={titleClasses.title}>
+            Rounds
+          </Typography>
+        </Grid>
+        <Grid item>
+          {currentPlayer.role === PlayerRole.Host ? (
+            <ControllableRoundSettings></ControllableRoundSettings>
+          ) : (
+            <RoundSettings></RoundSettings>
+          )}
         </Grid>
       </Grid>
     </Grid>
@@ -136,10 +144,6 @@ function Lobby() {
           <Divider variant="middle"></Divider>
           <div className={classes.section}>
             <SettingsSection></SettingsSection>
-          </div>
-          <Divider variant="middle"></Divider>
-          <div className={classes.section}>
-            <HowToPlay></HowToPlay>
           </div>
         </>
       )}

--- a/app/src/pages/Lobby/operations.graphql
+++ b/app/src/pages/Lobby/operations.graphql
@@ -23,9 +23,32 @@ mutation RemovePlayer($id: uuid!) {
   }
 }
 
-mutation DeleteRound($id: uuid!) {
+mutation DeleteRound(
+  $id: uuid!
+  $gameId: uuid!
+  $rounds: [rounds_insert_input!]!
+) {
   delete_rounds_by_pk(id: $id) {
     id
+  }
+  insert_games_one(
+    object: {
+      id: $gameId
+      rounds: {
+        data: $rounds
+        on_conflict: {
+          constraint: rounds_pkey
+          update_columns: [order_sequence]
+        }
+      }
+    }
+    on_conflict: { constraint: games_pkey, update_columns: [id] }
+  ) {
+    id
+    rounds {
+      id
+      order_sequence
+    }
   }
 }
 

--- a/app/src/pages/Lobby/operations.graphql
+++ b/app/src/pages/Lobby/operations.graphql
@@ -22,3 +22,39 @@ mutation RemovePlayer($id: uuid!) {
     id
   }
 }
+
+mutation DeleteRound($id: uuid!) {
+  delete_rounds_by_pk(id: $id) {
+    id
+  }
+}
+
+mutation UpdateAllRounds($gameId: uuid!, $rounds: [rounds_insert_input!]!) {
+  insert_games_one(
+    object: {
+      id: $gameId
+      rounds: {
+        data: $rounds
+        on_conflict: {
+          constraint: rounds_pkey
+          update_columns: [order_sequence]
+        }
+      }
+    }
+    on_conflict: { constraint: games_pkey, update_columns: [id] }
+  ) {
+    id
+    rounds {
+      id
+      order_sequence
+    }
+  }
+}
+
+mutation AddRound($object: rounds_insert_input!) {
+  insert_rounds_one(object: $object) {
+    id
+    value
+    order_sequence
+  }
+}

--- a/app/src/pages/Play/GameRoundInstructionCard.tsx
+++ b/app/src/pages/Play/GameRoundInstructionCard.tsx
@@ -8,6 +8,12 @@ export enum GameRound {
   Password = "Password"
 }
 
+export const GameRounds = [
+  GameRound.Taboo,
+  GameRound.Charades,
+  GameRound.Password
+]
+
 export const GameRoundDescription = {
   [GameRound.Taboo]: (
     <>
@@ -30,7 +36,7 @@ export const GameRoundDescription = {
 }
 
 function GameRoundInstructionCard(props: {
-  round: GameRound
+  round: GameRound | string
   roundNumber: number
   onDismiss: () => void
 }) {
@@ -43,7 +49,10 @@ function GameRoundInstructionCard(props: {
           {props.round}
         </Typography>
       </Box>
-      <Box p={1}>{GameRoundDescription[props.round]}</Box>
+      <Box p={1}>
+        {GameRoundDescription[props.round as GameRound] ||
+          "Your host will give you the rules for this one!"}
+      </Box>
       <Box p={1} display="flex" flexDirection="row-reverse">
         <Button
           color="primary"

--- a/app/src/pages/Play/HostControls.tsx
+++ b/app/src/pages/Play/HostControls.tsx
@@ -43,7 +43,7 @@ function HostControls(props: {
           style={{
             width: 150,
             height: 1,
-            backgroundColor: grey[500]
+            backgroundColor: grey[600]
           }}
         ></Divider>
       </Grid>

--- a/app/src/pages/Play/YourTurnContent.tsx
+++ b/app/src/pages/Play/YourTurnContent.tsx
@@ -35,7 +35,7 @@ enum ShownCardStatus {
 
 const GreenCheckbox = withStyles({
   root: {
-    color: grey[500],
+    color: grey[600],
     "&$checked": {
       color: green[600]
     }
@@ -147,7 +147,7 @@ function YourTurnContent(props: {
                 {activeCard ? (
                   <Typography variant="h5">{activeCard.word}</Typography>
                 ) : (
-                  <div style={{ textAlign: "center", color: grey[500] }}>
+                  <div style={{ textAlign: "center", color: grey[600] }}>
                     You'll see cards here!
                   </div>
                 )}
@@ -196,7 +196,7 @@ function YourTurnContent(props: {
                       </Box>
                       {shownCardsInActiveTurn.get(cardId) ===
                         ShownCardStatus.Skipped && (
-                        <Box color={grey[500]}>(skip)</Box>
+                        <Box color={grey[600]}>(skip)</Box>
                       )}
                     </Grid>
                     <Grid item>
@@ -354,7 +354,7 @@ function YourTurnContent(props: {
 
         {!isMobile &&
           props.activeTurnPlayState === ActiveTurnPlayState.Playing && (
-            <Grid item style={{ color: grey[500] }}>
+            <Grid item style={{ color: grey[600] }}>
               Hint: Press the spacebar for "Correct", and S for "Skip"
             </Grid>
           )}

--- a/app/src/pages/Play/index.tsx
+++ b/app/src/pages/Play/index.tsx
@@ -159,7 +159,7 @@ function Play() {
   let round
   if (roundMarkers.includes(roundMarker)) {
     const value = capitalize(currentGame.rounds[roundMarker].value)
-    round = GameRound[value as GameRound]
+    round = GameRound[value as GameRound] || value
   }
 
   return (

--- a/app/src/pages/TeamAssignment/index.tsx
+++ b/app/src/pages/TeamAssignment/index.tsx
@@ -53,7 +53,7 @@ function TeamAssignment() {
               {`Team ${myTeamColor}`.toLocaleUpperCase()}
             </Typography>
           </Grid>
-          <Grid item style={{ color: grey[500], fontStyle: "italic" }}>
+          <Grid item style={{ color: grey[600], fontStyle: "italic" }}>
             (your team)
           </Grid>
         </Grid>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1880,6 +1880,13 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@types/array-move@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/array-move/-/array-move-2.0.0.tgz#cc5eddfce1d5f161d084c41e718b416113f14502"
+  integrity sha512-M1Sb7db3XP65S2j5CWvzce2z0ORRfT/Bhd6mYu++nP6ZhRsntMixavFyxgf9NkQa37bveuIfpb0RKYRA8XVcGQ==
+  dependencies:
+    array-move "*"
+
 "@types/babel__core@^7.1.0":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.6.tgz#16ff42a5ae203c9af1c6e190ed1f30f83207b610"
@@ -2760,6 +2767,11 @@ array-includes@^3.0.3, array-includes@^3.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.0"
     is-string "^1.0.5"
+
+array-move@*, array-move@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/array-move/-/array-move-2.2.1.tgz#16d5b68cb949c43e8821d63e4622f3a3336f254d"
+  integrity sha512-qQpEHBnVT6HAFgEVUwRdHVd8TYJThrZIT5wSXpEUTPwBaYhPLclw12mEpyUvRWVdl1VwPOqnIy6LqTFN3cSeUQ==
 
 array-union@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
# Screenshots

## Host - Lobby, Desktop

![image](https://user-images.githubusercontent.com/2534903/80632521-3dd79280-8a0c-11ea-873c-91e932dfaabb.png)

## Host - Lobby, Mobile

![image](https://user-images.githubusercontent.com/2534903/80632653-6c556d80-8a0c-11ea-8ddc-53b8e161d83e.png)

## Participant - Lobby, Mobile

![image](https://user-images.githubusercontent.com/2534903/80632622-5f387e80-8a0c-11ea-91db-66a98c3911ea.png)

## Host/Participant - Active play, Mobile