### PR TITLE
set default for seconds per turn

### DIFF
--- a/graphql-server/migrations/1588305432355_alter_table_public_games_alter_column_seconds_per_turn/down.yaml
+++ b/graphql-server/migrations/1588305432355_alter_table_public_games_alter_column_seconds_per_turn/down.yaml
@@ -1,0 +1,10 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."games" ALTER COLUMN "seconds_per_turn" TYPE integer;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE ONLY "public"."games" ALTER COLUMN "seconds_per_turn" DROP DEFAULT;
+  type: run_sql

--- a/graphql-server/migrations/1588305432355_alter_table_public_games_alter_column_seconds_per_turn/up.yaml
+++ b/graphql-server/migrations/1588305432355_alter_table_public_games_alter_column_seconds_per_turn/up.yaml
@@ -1,0 +1,11 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."games" ALTER COLUMN "seconds_per_turn" TYPE int4;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE ONLY "public"."games" ALTER COLUMN "seconds_per_turn" SET DEFAULT
+      60;
+  type: run_sql


### PR DESCRIPTION
how to:

Open Hasura console on `localhost:9695` (to track migrations)

```bash
cd graphql-server
hasura console --admin-secret=myadminsecretkey
```

update default here:

![image](https://user-images.githubusercontent.com/2534903/80781139-21c81400-8b26-11ea-8f02-b18b14e23400.png)

Post merge follow up:
- I'll run these migrations against prod
- Eventually, I'd like to make this column non nullable for better typing in FE -- so may need to backfill all previous games with some number (prob 60).