### PR TITLE
Make Settings Section collapsable

### DIFF
--- a/app/src/pages/Lobby/index.tsx
+++ b/app/src/pages/Lobby/index.tsx
@@ -65,7 +65,7 @@ function SettingsSection() {
           Settings
         </Typography>
       </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      <ExpansionPanelDetails style={{ padding: 0 }}>
         <Grid item>
           <Grid container spacing={2} direction="column">
             <Grid item>

--- a/app/src/pages/Lobby/index.tsx
+++ b/app/src/pages/Lobby/index.tsx
@@ -2,12 +2,16 @@ import {
   Box,
   createStyles,
   Divider,
+  ExpansionPanel,
+  ExpansionPanelDetails,
+  ExpansionPanelSummary,
   Grid,
   makeStyles,
   Theme,
   Typography
 } from "@material-ui/core"
 import { grey } from "@material-ui/core/colors"
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import { CurrentGameContext } from "contexts/CurrentGame"
 import { CurrentPlayerContext, PlayerRole } from "contexts/CurrentPlayer"
 import { useTitleStyle } from "index"
@@ -45,55 +49,68 @@ function SettingsSection() {
   const currentPlayer = React.useContext(CurrentPlayerContext)
   const titleClasses = useTitleStyle()
   return (
-    <Grid item>
-      <Grid container spacing={2} direction="column">
+    <ExpansionPanel
+      style={{
+        boxShadow: "none",
+        background: "none"
+      }}
+    >
+      <ExpansionPanelSummary
+        expandIcon={<ExpandMoreIcon />}
+        style={{ padding: 0 }}
+        aria-controls="panel1a-content"
+        id="panel1a-header"
+      >
+        <Typography variant="h4" className={titleClasses.title}>
+          Settings
+        </Typography>
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails>
         <Grid item>
-          <Typography variant="h4" className={titleClasses.title}>
-            Settings
-          </Typography>
-          {currentPlayer.role === PlayerRole.Participant && (
-            <div style={{ color: grey[600] }}>
-              (Only your host can set these)
-            </div>
-          )}
+          <Grid container spacing={2} direction="column">
+            <Grid item>
+              {currentPlayer.role === PlayerRole.Participant && (
+                <div style={{ color: grey[600] }}>
+                  (Only your host can set these)
+                </div>
+              )}
+            </Grid>
+            <Grid item>
+              <SecondsPerTurnInput
+                value={String(currentGame.seconds_per_turn || "")}
+              ></SecondsPerTurnInput>
+            </Grid>
+            <Grid item>
+              <SubmissionsPerPlayerInput
+                value={String(currentGame.num_entries_per_player || "")}
+              ></SubmissionsPerPlayerInput>
+            </Grid>
+            <Grid item>
+              <LetterInput
+                value={currentGame.starting_letter || ""}
+              ></LetterInput>
+            </Grid>
+            <Grid item>
+              <Typography variant="h6" className={titleClasses.title}>
+                Rounds
+              </Typography>
+              <Box pl={2} pt={1} fontSize="0.75rem" color={grey[600]}>
+                {currentPlayer.role === PlayerRole.Host &&
+                  "You can add, remove, or reorder rounds. By default, cards submitted will be re-used across rounds of Taboo, Charades, and Password."}
+              </Box>
+            </Grid>
+            <Grid item>
+              {currentPlayer.role === PlayerRole.Host ? (
+                <ControllableRoundSettings></ControllableRoundSettings>
+              ) : (
+                <RoundSettings></RoundSettings>
+              )}
+            </Grid>
+            <Grid item></Grid>
+          </Grid>
         </Grid>
-        <Grid item>
-          <SecondsPerTurnInput
-            value={String(currentGame.seconds_per_turn || "")}
-          ></SecondsPerTurnInput>
-        </Grid>
-        <Grid item>
-          <Typography variant="h6" className={titleClasses.title}>
-            Cards
-          </Typography>
-        </Grid>
-        <Grid item>
-          <SubmissionsPerPlayerInput
-            value={String(currentGame.num_entries_per_player || "")}
-          ></SubmissionsPerPlayerInput>
-        </Grid>
-        <Grid item>
-          <LetterInput value={currentGame.starting_letter || ""}></LetterInput>
-        </Grid>
-        <Grid item>
-          <Typography variant="h6" className={titleClasses.title}>
-            Rounds
-          </Typography>
-          <Box pl={2} pt={1} fontSize="0.75rem" color={grey[600]}>
-            {currentPlayer.role === PlayerRole.Host &&
-              "You can add, remove, or reorder rounds. By default, cards submitted will be re-used across rounds of Taboo, Charades, and Password."}
-          </Box>
-        </Grid>
-        <Grid item>
-          {currentPlayer.role === PlayerRole.Host ? (
-            <ControllableRoundSettings></ControllableRoundSettings>
-          ) : (
-            <RoundSettings></RoundSettings>
-          )}
-        </Grid>
-        <Grid item></Grid>
-      </Grid>
-    </Grid>
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
   )
 }
 


### PR DESCRIPTION
https://trello.com/c/a2gAethJ/74-s-make-setting-section-collapsable

Should we hide the settings section altogether if you're not the host?

# Desktop
## Collapsed (default)
<img width="902" alt="Play_the_Fishbowl_Game__aka_Salad_Bowl__-_Online___Free" src="https://user-images.githubusercontent.com/3579673/80782430-0c091d80-8b2b-11ea-9bef-7e00d8edc357.png">

## Expanded
<img width="819" alt="Play_the_Fishbowl_Game__aka_Salad_Bowl__-_Online___Free" src="https://user-images.githubusercontent.com/3579673/80782458-293dec00-8b2b-11ea-9aef-8bd68f22dd55.png">


# Mobile

## Collapsed (default)

<img width="424" alt="Play_the_Fishbowl_Game__aka_Salad_Bowl__-_Online___Free" src="https://user-images.githubusercontent.com/3579673/80782413-f4ca3000-8b2a-11ea-83ea-771896ac03c4.png">


## Expanded
<img width="409" alt="Play_the_Fishbowl_Game__aka_Salad_Bowl__-_Online___Free" src="https://user-images.githubusercontent.com/3579673/80782397-e2e88d00-8b2a-11ea-970d-7ea07de3c759.png">
