### PR TITLE
add turn scorings table + permissions + relationships

### DIFF
--- a/graphql-server/migrations/1588958405887_create_table_public_turn_scorings/down.yaml
+++ b/graphql-server/migrations/1588958405887_create_table_public_turn_scorings/down.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: DROP TABLE "public"."turn_scorings";
+  type: run_sql

--- a/graphql-server/migrations/1588958405887_create_table_public_turn_scorings/up.yaml
+++ b/graphql-server/migrations/1588958405887_create_table_public_turn_scorings/up.yaml
@@ -1,0 +1,23 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: CREATE TABLE "public"."turn_scorings"("id" uuid NOT NULL DEFAULT gen_random_uuid(),
+      "turn_id" uuid NOT NULL, "card_id" uuid NOT NULL, "round_id" uuid NOT NULL,
+      "player_id" uuid NOT NULL, "score" integer NOT NULL, "skipped" boolean NOT NULL,
+      "started_at" timestamptz NOT NULL, "ended_at" timestamptz NOT NULL, "game_id"
+      uuid NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("turn_id") REFERENCES "public"."turns"("id")
+      ON UPDATE restrict ON DELETE restrict, FOREIGN KEY ("card_id") REFERENCES "public"."cards"("id")
+      ON UPDATE restrict ON DELETE restrict, FOREIGN KEY ("game_id") REFERENCES "public"."games"("id")
+      ON UPDATE restrict ON DELETE restrict, FOREIGN KEY ("round_id") REFERENCES "public"."rounds"("id")
+      ON UPDATE restrict ON DELETE restrict, FOREIGN KEY ("player_id") REFERENCES
+      "public"."players"("id") ON UPDATE restrict ON DELETE restrict);
+  type: run_sql
+- args:
+    name: turn_scorings
+    schema: public
+  type: add_existing_table_or_view

--- a/graphql-server/migrations/1588958490767_alter_table_public_turn_scorings_drop_column_game_id/down.yaml
+++ b/graphql-server/migrations/1588958490767_alter_table_public_turn_scorings_drop_column_game_id/down.yaml
@@ -1,0 +1,17 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD COLUMN "game_id" uuid;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ALTER COLUMN "game_id" DROP NOT NULL;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD CONSTRAINT turn_scorings_game_id_fkey
+      FOREIGN KEY (game_id) REFERENCES "public"."games" (id) ON DELETE restrict ON
+      UPDATE restrict;
+  type: run_sql

--- a/graphql-server/migrations/1588958490767_alter_table_public_turn_scorings_drop_column_game_id/up.yaml
+++ b/graphql-server/migrations/1588958490767_alter_table_public_turn_scorings_drop_column_game_id/up.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" DROP COLUMN "game_id" CASCADE;
+  type: run_sql

--- a/graphql-server/migrations/1588958516268_alter_table_public_turn_scorings_drop_column_player_id/down.yaml
+++ b/graphql-server/migrations/1588958516268_alter_table_public_turn_scorings_drop_column_player_id/down.yaml
@@ -1,0 +1,17 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD COLUMN "player_id" uuid;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ALTER COLUMN "player_id" DROP NOT NULL;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD CONSTRAINT turn_scorings_player_id_fkey
+      FOREIGN KEY (player_id) REFERENCES "public"."players" (id) ON DELETE restrict
+      ON UPDATE restrict;
+  type: run_sql

--- a/graphql-server/migrations/1588958516268_alter_table_public_turn_scorings_drop_column_player_id/up.yaml
+++ b/graphql-server/migrations/1588958516268_alter_table_public_turn_scorings_drop_column_player_id/up.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" DROP COLUMN "player_id" CASCADE;
+  type: run_sql

--- a/graphql-server/migrations/1588958524810_alter_table_public_turn_scorings_drop_column_round_id/down.yaml
+++ b/graphql-server/migrations/1588958524810_alter_table_public_turn_scorings_drop_column_round_id/down.yaml
@@ -1,0 +1,17 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD COLUMN "round_id" uuid;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ALTER COLUMN "round_id" DROP NOT NULL;
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" ADD CONSTRAINT turn_scorings_round_id_fkey
+      FOREIGN KEY (round_id) REFERENCES "public"."rounds" (id) ON DELETE restrict
+      ON UPDATE restrict;
+  type: run_sql

--- a/graphql-server/migrations/1588958524810_alter_table_public_turn_scorings_drop_column_round_id/up.yaml
+++ b/graphql-server/migrations/1588958524810_alter_table_public_turn_scorings_drop_column_round_id/up.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: ALTER TABLE "public"."turn_scorings" DROP COLUMN "round_id" CASCADE;
+  type: run_sql

--- a/graphql-server/migrations/1588958610037_add_relationship__table_public_turns/down.yaml
+++ b/graphql-server/migrations/1588958610037_add_relationship__table_public_turns/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    relationship: scorings
+    table:
+      name: turns
+      schema: public
+  type: drop_relationship

--- a/graphql-server/migrations/1588958610037_add_relationship__table_public_turns/up.yaml
+++ b/graphql-server/migrations/1588958610037_add_relationship__table_public_turns/up.yaml
@@ -1,0 +1,12 @@
+- args:
+    name: scorings
+    table:
+      name: turns
+      schema: public
+    using:
+      foreign_key_constraint_on:
+        column: turn_id
+        table:
+          name: turn_scorings
+          schema: public
+  type: create_array_relationship

--- a/graphql-server/migrations/1588958633885_add_relationship__table_public_turn_scorings/down.yaml
+++ b/graphql-server/migrations/1588958633885_add_relationship__table_public_turn_scorings/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    relationship: turn
+    table:
+      name: turn_scorings
+      schema: public
+  type: drop_relationship

--- a/graphql-server/migrations/1588958633885_add_relationship__table_public_turn_scorings/up.yaml
+++ b/graphql-server/migrations/1588958633885_add_relationship__table_public_turn_scorings/up.yaml
@@ -1,0 +1,8 @@
+- args:
+    name: turn
+    table:
+      name: turn_scorings
+      schema: public
+    using:
+      foreign_key_constraint_on: turn_id
+  type: create_object_relationship

--- a/graphql-server/migrations/1588958737554_update_permission_player_public_table_turn_scorings/down.yaml
+++ b/graphql-server/migrations/1588958737554_update_permission_player_public_table_turn_scorings/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: drop_insert_permission

--- a/graphql-server/migrations/1588958737554_update_permission_player_public_table_turn_scorings/up.yaml
+++ b/graphql-server/migrations/1588958737554_update_permission_player_public_table_turn_scorings/up.yaml
@@ -1,0 +1,22 @@
+- args:
+    permission:
+      allow_upsert: true
+      backend_only: false
+      check:
+        turn:
+          player_id:
+            _eq: X-Hasura-User-Id
+      columns:
+      - card_id
+      - ended_at
+      - id
+      - score
+      - skipped
+      - started_at
+      - turn_id
+      set: {}
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: create_insert_permission

--- a/graphql-server/migrations/1588958827666_update_permission_player_public_table_turn_scorings/down.yaml
+++ b/graphql-server/migrations/1588958827666_update_permission_player_public_table_turn_scorings/down.yaml
@@ -1,0 +1,6 @@
+- args:
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: drop_select_permission

--- a/graphql-server/migrations/1588958827666_update_permission_player_public_table_turn_scorings/up.yaml
+++ b/graphql-server/migrations/1588958827666_update_permission_player_public_table_turn_scorings/up.yaml
@@ -1,0 +1,18 @@
+- args:
+    permission:
+      allow_aggregations: false
+      backend_only: false
+      columns: []
+      computed_fields: []
+      filter:
+        turn:
+          game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+      limit: null
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: create_select_permission

--- a/graphql-server/migrations/1588959236573_update_permission_player_public_table_turn_scorings/down.yaml
+++ b/graphql-server/migrations/1588959236573_update_permission_player_public_table_turn_scorings/down.yaml
@@ -1,0 +1,22 @@
+- args:
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: false
+      columns: []
+      computed_fields: []
+      filter:
+        turn:
+          game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: create_select_permission

--- a/graphql-server/migrations/1588959236573_update_permission_player_public_table_turn_scorings/up.yaml
+++ b/graphql-server/migrations/1588959236573_update_permission_player_public_table_turn_scorings/up.yaml
@@ -1,0 +1,29 @@
+- args:
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: drop_select_permission
+- args:
+    permission:
+      allow_aggregations: false
+      columns:
+      - id
+      - turn_id
+      - card_id
+      - score
+      - skipped
+      - started_at
+      - ended_at
+      computed_fields: []
+      filter:
+        turn:
+          game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+    role: player
+    table:
+      name: turn_scorings
+      schema: public
+  type: create_select_permission

--- a/graphql-server/migrations/metadata.yaml
+++ b/graphql-server/migrations/metadata.yaml
@@ -1,0 +1,427 @@
+version: 2
+tables:
+- table:
+    schema: public
+    name: cards
+  object_relationships:
+  - name: game
+    using:
+      foreign_key_constraint_on: game_id
+  insert_permissions:
+  - role: player
+    permission:
+      check:
+        _and:
+        - game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+        - player_id:
+            _eq: X-Hasura-User-Id
+      columns:
+      - game_id
+      - player_id
+      - word
+  select_permissions:
+  - role: player
+    permission:
+      columns:
+      - id
+      - game_id
+      - player_id
+      - word
+      - created_at
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - word
+      filter:
+        _and:
+        - game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+        - player_id:
+            _eq: X-Hasura-User-Id
+      check: null
+- table:
+    schema: public
+    name: game_state
+  is_enum: true
+- table:
+    schema: public
+    name: games
+  object_relationships:
+  - name: host
+    using:
+      foreign_key_constraint_on: host_id
+  array_relationships:
+  - name: cards
+    using:
+      foreign_key_constraint_on:
+        column: game_id
+        table:
+          schema: public
+          name: cards
+  - name: players
+    using:
+      foreign_key_constraint_on:
+        column: game_id
+        table:
+          schema: public
+          name: players
+  - name: rounds
+    using:
+      foreign_key_constraint_on:
+        column: game_id
+        table:
+          schema: public
+          name: rounds
+  - name: turns
+    using:
+      foreign_key_constraint_on:
+        column: game_id
+        table:
+          schema: public
+          name: turns
+  insert_permissions:
+  - role: anonymous
+    permission:
+      check: {}
+      columns: []
+  - role: player
+    permission:
+      check:
+        players:
+          id:
+            _eq: X-Hasura-User-Id
+      columns:
+      - id
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - id
+      - join_code
+      filter: {}
+  - role: player
+    permission:
+      columns:
+      - id
+      - join_code
+      - state
+      - host_id
+      - starting_letter
+      - seconds_per_turn
+      - num_entries_per_player
+      - created_at
+      filter:
+        players:
+          id:
+            _eq: X-Hasura-User-Id
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - created_at
+      - host_id
+      - id
+      - join_code
+      - num_entries_per_player
+      - seconds_per_turn
+      - starting_letter
+      - state
+      filter:
+        players:
+          id:
+            _eq: X-Hasura-User-Id
+      check: null
+- table:
+    schema: public
+    name: players
+  object_relationships:
+  - name: game
+    using:
+      foreign_key_constraint_on: game_id
+  insert_permissions:
+  - role: anonymous
+    permission:
+      check:
+        game:
+          state:
+            _eq: lobby
+      columns:
+      - client_uuid
+      - game_id
+  - role: player
+    permission:
+      check:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+      columns:
+      - client_uuid
+      - game_id
+      - id
+      - team
+      - team_sequence
+      - username
+  select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+      - client_uuid
+      - game_id
+      - id
+      filter: {}
+  - role: player
+    permission:
+      columns:
+      - id
+      - client_uuid
+      - game_id
+      - username
+      - team
+      - team_sequence
+      - created_at
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - team
+      - team_sequence
+      - username
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+      check: null
+  delete_permissions:
+  - role: player
+    permission:
+      filter:
+        _and:
+        - game:
+            host:
+              id:
+                _eq: X-Hasura-User-Id
+        - game:
+            state:
+              _eq: lobby
+- table:
+    schema: public
+    name: rounds
+  object_relationships:
+  - name: game
+    using:
+      foreign_key_constraint_on: game_id
+  insert_permissions:
+  - role: player
+    permission:
+      check:
+        _and:
+        - game:
+            host_id:
+              _eq: X-Hasura-User-Id
+        - game:
+            state:
+              _eq: lobby
+        - game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+      columns:
+      - game_id
+      - id
+      - order_sequence
+      - value
+  select_permissions:
+  - role: player
+    permission:
+      columns:
+      - id
+      - order_sequence
+      - value
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - order_sequence
+      filter:
+        _and:
+        - game:
+            host_id:
+              _eq: X-Hasura-User-Id
+        - game:
+            state:
+              _eq: lobby
+        - game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+      check: null
+  delete_permissions:
+  - role: player
+    permission:
+      filter:
+        _and:
+        - game:
+            host_id:
+              _eq: X-Hasura-User-Id
+        - game:
+            state:
+              _eq: lobby
+        - game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+- table:
+    schema: public
+    name: turn_scorings
+  object_relationships:
+  - name: turn
+    using:
+      foreign_key_constraint_on: turn_id
+  insert_permissions:
+  - role: player
+    permission:
+      check:
+        turn:
+          player_id:
+            _eq: X-Hasura-User-Id
+      columns:
+      - card_id
+      - ended_at
+      - id
+      - score
+      - skipped
+      - started_at
+      - turn_id
+      backend_only: false
+  select_permissions:
+  - role: player
+    permission:
+      columns:
+      - id
+      - turn_id
+      - card_id
+      - score
+      - skipped
+      - started_at
+      - ended_at
+      filter:
+        turn:
+          game:
+            players:
+              id:
+                _eq: X-Hasura-User-Id
+- table:
+    schema: public
+    name: turns
+  object_relationships:
+  - name: game
+    using:
+      foreign_key_constraint_on: game_id
+  - name: player
+    using:
+      foreign_key_constraint_on: player_id
+  array_relationships:
+  - name: scorings
+    using:
+      foreign_key_constraint_on:
+        column: turn_id
+        table:
+          schema: public
+          name: turn_scorings
+  insert_permissions:
+  - role: player
+    permission:
+      check:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+      columns:
+      - completed_card_ids
+      - ended_at
+      - game_id
+      - player_id
+      - seconds_per_turn_override
+      - started_at
+  select_permissions:
+  - role: player
+    permission:
+      columns:
+      - completed_card_ids
+      - created_at
+      - ended_at
+      - game_id
+      - id
+      - player_id
+      - review_started_at
+      - seconds_per_turn_override
+      - sequential_id
+      - started_at
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+  update_permissions:
+  - role: player
+    permission:
+      columns:
+      - completed_card_ids
+      - ended_at
+      - game_id
+      - player_id
+      - review_started_at
+      - seconds_per_turn_override
+      - started_at
+      filter:
+        game:
+          players:
+            id:
+              _eq: X-Hasura-User-Id
+      check: null
+actions:
+- name: joinGame
+  definition:
+    handler: '{{ACTION_BASE_ENDPOINT}}/joinGame'
+    output_type: joinGameOutput
+    arguments:
+    - name: gameId
+      type: String!
+    - name: clientUuid
+      type: String!
+    type: mutation
+    kind: synchronous
+  permissions:
+  - role: anonymous
+  - role: player
+custom_types:
+  objects:
+  - name: joinGameOutput
+    fields:
+    - name: id
+      type: String!
+    - name: jwt_token
+      type: String!


### PR DESCRIPTION
So eventually we can have

```
mutation EndCurrentTurnAndStartNextTurn(
  $currentTurnId: uuid!
  $completedCardIds: jsonb!
  $endedAt: timestamptz!
  $gameId: uuid!
  $nextTurnplayerId: uuid!
  $nextTurnSecondsPerTurnOverride: Int
  $currentTurnScorings: [turn_scorings_insert_input!]!
) {
  insert_turn_scorings(objects: $currentTurnScorings) {
    returning {
      id
    }
  }
  update_turns_by_pk(
    pk_columns: { id: $currentTurnId }
    _set: { ended_at: $endedAt, completed_card_ids: $completedCardIds }
  ) {
    id
    ended_at
    completed_card_ids
  }
  insert_turns_one(
    object: {
      game_id: $gameId
      player_id: $nextTurnplayerId
      seconds_per_turn_override: $nextTurnSecondsPerTurnOverride
    }
  ) {
    id
    game_id
    player_id
    seconds_per_turn_override
  }
}
```

So then we can have [-1, 0 +1] button group module add the card review step.

Looks like...

![image](https://user-images.githubusercontent.com/2534903/81432181-52f0a780-9117-11ea-8da2-d6ddf2951570.png)
