### PR TITLE
Prototype deploy-hasura command

### DIFF
--- a/.github/workflows/deploy-hasura-command.yml
+++ b/.github/workflows/deploy-hasura-command.yml
@@ -1,0 +1,22 @@
+name: deploy-hasura-command
+on:
+  repository_dispatch:
+    types: [deploy-hasura-command]
+jobs:
+  deployHasura:
+    runs-on: ubuntu-latest
+    env:
+      HASURA_ENDPOINT: ${{ secrets.HASURA_ENDPOINT }}
+      HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
+      HASURA_WORKDIR: graphql-server
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Apply Hasura migrations
+        uses: tibotiber/hasura-action@master
+        with:
+          args: migrate apply
+      - name: Apply Hasura metadata
+        uses: tibotiber/hasura-action@master
+        with:
+          args: metadata apply

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,16 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: deploy-hasura
+          permission: admin
+          issue-type: pull-request


### PR DESCRIPTION
Prototypes `/deploy-hasura` "ChatOps" command with [Slash Command Dispatch](https://github.com/peter-evans/slash-command-dispatch) and [GitHub Actions for Hasura](https://github.com/tibotiber/hasura-action).

This is a proposed prerequisite approach that starts to split GraphQL and front end deployments. Given that we don't have a straightforward way to react to "post-deploy" GraphQL events, this would theoretically enable one to apply Hasura migrations / metadata _before_ merging pull requests / deploying the front end.

Theoretical flow:

1. Admin comments on a pull request with `/deploy-hasura`
2. Applies Hasura migrations / metadata
3. Merge PR
4. Front-end build kicks off, generating GraphQL JavaScript code from the live server

## Todo

- [ ] Vet approach
- [ ] Configure PAT / secrets
- [ ] Add GraphQL code generation to front end build