### PR TITLE
Add 🚀🦀 rocketcrab support

### DIFF
--- a/actions-server/src/handlers/newGame.ts
+++ b/actions-server/src/handlers/newGame.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from "express"
+import { DocumentNode, print as gqlToString } from "graphql"
+import fetch from "node-fetch"
+import {
+  StartGame,
+  StartGameMutationVariables,
+  GameById,
+  GameByIdQueryVariables,
+} from "../generated/graphql"
+
+// execute the parent operation in Hasura
+const execute = async <T>(query: DocumentNode, variables: T) => {
+  const fetchResponse = await fetch(
+    process.env.HASURA_ENDPOINT || "missing endpoint",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        query: gqlToString(query),
+        variables: variables,
+      }),
+    }
+  )
+  const data = await fetchResponse.json()
+  console.log("DEBUG: ", data)
+  return data
+}
+
+// Request Handler
+const handler = async (req: Request, res: Response) => {
+  // execute the Hasura operation(s)
+  const {
+    data: {
+      insert_games_one: { id },
+    },
+    errors: err1,
+  } = await execute<StartGameMutationVariables>(StartGame, {})
+  if (err1) {
+    return res.status(400).json(err1[0])
+  }
+
+  const {
+    data: {
+      games_by_pk: { join_code },
+    },
+    errors: err2,
+  } = await execute<GameByIdQueryVariables>(GameById, {
+    id,
+  })
+  if (err2) {
+    return res.status(400).json(err2[0])
+  }
+
+  return res.json({
+    join_code,
+  })
+}
+
+module.exports = handler

--- a/actions-server/src/handlers/operations.graphql
+++ b/actions-server/src/handlers/operations.graphql
@@ -11,3 +11,15 @@ query LookupPlayerForGame($gameId: uuid!, $clientUuid: uuid!) {
     id
   }
 }
+
+mutation StartGame {
+  insert_games_one(object: {}) {
+    id
+  }
+}
+
+query GameById($id: uuid!) {
+  games_by_pk(id: $id) {
+    join_code
+  }
+}

--- a/actions-server/src/handlers/operations.graphql
+++ b/actions-server/src/handlers/operations.graphql
@@ -1,6 +1,11 @@
 mutation InsertPlayerForGame($gameId: uuid!, $clientUuid: uuid!) {
   insert_players_one(object: { game_id: $gameId, client_uuid: $clientUuid }) {
     id
+    game {
+      host {
+        id
+      }
+    }
   }
 }
 
@@ -9,6 +14,11 @@ query LookupPlayerForGame($gameId: uuid!, $clientUuid: uuid!) {
     where: { game_id: { _eq: $gameId }, client_uuid: { _eq: $clientUuid } }
   ) {
     id
+    game {
+      host {
+        id
+      }
+    }
   }
 }
 
@@ -21,5 +31,14 @@ mutation StartGame {
 query GameById($id: uuid!) {
   games_by_pk(id: $id) {
     join_code
+  }
+}
+
+mutation BecomeHost($gameId: uuid!, $playerId: uuid!) {
+  update_games_by_pk(
+    pk_columns: { id: $gameId }
+    _set: { host_id: $playerId }
+  ) {
+    id
   }
 }

--- a/app/src/pages/Lobby/index.tsx
+++ b/app/src/pages/Lobby/index.tsx
@@ -30,6 +30,8 @@ import RoundSettings from "pages/Lobby/RoundSettings"
 import WaitingRoom from "pages/Lobby/WaitingRoom"
 import * as React from "react"
 import Clipboard from "react-clipboard.js"
+import { useLocation } from "react-router-dom"
+import { useUpdatePlayerMutation } from "generated/graphql"
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -209,13 +211,44 @@ function WaitingRoomSection() {
 
 function Lobby() {
   const currentPlayer = React.useContext(CurrentPlayerContext)
+  const [updatePlayer] = useUpdatePlayerMutation()
   const classes = useStyles()
+  const titleClasses = useTitleStyle()
+  const location = useLocation()
+  const [hideShare, setHideShare] = React.useState(false)
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(location.search)
+
+    setHideShare(params.get("hideshare") === "true")
+
+    const username = params.get("name")
+    if (username) {
+      updatePlayer({
+        variables: {
+          id: currentPlayer.id,
+          input: { username },
+        },
+      })
+    }
+  }, [])
 
   return (
     <div>
-      <div className={classes.section}>
-        <ShareSection />
-      </div>
+      {!hideShare ? (
+        <div className={classes.section}>
+          <ShareSection />
+        </div>
+      ) : (
+        <Typography
+          variant="h4"
+          style={{ textAlign: "center", marginBottom: "1em" }}
+          className={titleClasses.title}
+        >
+          Fishbowl
+        </Typography>
+      )}
+
       <Divider variant="middle"></Divider>
 
       {currentPlayer.role === PlayerRole.Host && (


### PR DESCRIPTION
Hey folks! Love the game! Myself and a few other mobile web party game developers have been working on [rocketcrab](https://rocketcrab.com/), and we'd love to add Fishbowl! Many games can be added to 🚀🦀 without any changes, but Fishbowl needed a few changes to work. Here's what I've added in this PR:

- The rocketcrab server [needs a way](https://github.com/tannerkrewson/rocketcrab#step-1-ensuring-compatability) to create a lobby in supported games. So, I've added a `newGame` endpoint that generates an empty lobby, and returns its game code.
- This caused an issue where no player would be host. This is fixed by automatically making the first player that joins the host if there is not already a host.
- As a bonus, I've added code that will automatically set a player's username if a `name=John` param is added to the URL, and also hides the share section if a `hideshare=true` param is added to the URL. These two features will make a big difference for rocketcrab players! 🎉 

Let me know if you have any concerns, or you notice any mistakes. Also, [join our discord](https://discord.gg/MvYRVCP) if you'd like; we'd love to hear from you! 😄 