### PR TITLE
UsernameInput: Set maximum username length to 20

### DIFF
--- a/app/src/pages/Lobby/Inputs/UsernameInput.tsx
+++ b/app/src/pages/Lobby/Inputs/UsernameInput.tsx
@@ -1,26 +1,26 @@
-import { Box, Button, TextField } from "@material-ui/core"
-import { Players, useUpdatePlayerMutation } from "generated/graphql"
-import * as React from "react"
-import { useTranslation } from "react-i18next"
+import { Box, Button, TextField } from "@material-ui/core";
+import { Players, useUpdatePlayerMutation } from "generated/graphql";
+import * as React from "react";
+import { useTranslation } from "react-i18next";
 
 function UsernameInput(props: { playerId: Players["id"]; username: string }) {
-  const { t } = useTranslation()
-  const [updatePlayer] = useUpdatePlayerMutation()
-  const [value, setValue] = React.useState(props.username || "")
-  const [savedName, setSavedName] = React.useState(value)
+  const { t } = useTranslation();
+  const [updatePlayer] = useUpdatePlayerMutation();
+  const [value, setValue] = React.useState(props.username || "");
+  const [savedName, setSavedName] = React.useState(value);
 
   return (
     <form
       onSubmit={async (event) => {
-        event.preventDefault()
+        event.preventDefault();
         const response = await updatePlayer({
           variables: {
             id: props.playerId,
             input: { username: value },
           },
-        })
+        });
         if (response.data?.update_players_by_pk?.username) {
-          setSavedName(value)
+          setSavedName(value);
         }
       }}
     >
@@ -31,11 +31,11 @@ function UsernameInput(props: { playerId: Players["id"]; username: string }) {
             variant="outlined"
             size="small"
             defaultValue={props.username || ""}
-			      // Added to prevent usernames longer than 20 characters, 
-			      // because many people play on mobile devices and you have to scroll with longer names.
-			      inputProps={{ maxLength: 20 }}
+            // Added to prevent usernames longer than 20 characters,
+            // because many people play on mobile devices and you have to scroll with longer names.
+            inputProps={{ maxLength: 20 }}
             onChange={({ target: { value } }) => {
-              setValue(value)
+              setValue(value);
             }}
             helperText={
               <span>
@@ -58,7 +58,8 @@ function UsernameInput(props: { playerId: Players["id"]; username: string }) {
         </Box>
       </Box>
     </form>
-  )
+  );
 }
 
-export default UsernameInput
+export default UsernameInput;
+

--- a/app/src/pages/Lobby/Inputs/UsernameInput.tsx
+++ b/app/src/pages/Lobby/Inputs/UsernameInput.tsx
@@ -33,7 +33,7 @@ function UsernameInput(props: { playerId: Players["id"]; username: string }) {
             defaultValue={props.username || ""}
             // Added to prevent usernames longer than 20 characters,
             // because many people play on mobile devices and you have to scroll with longer names.
-            inputProps={{ maxLength: 20 }}
+            inputProps={{ maxLength: 20 }} // changed to 20
             onChange={({ target: { value } }) => {
               setValue(value);
             }}

--- a/app/src/pages/Lobby/Inputs/UsernameInput.tsx
+++ b/app/src/pages/Lobby/Inputs/UsernameInput.tsx
@@ -31,6 +31,9 @@ function UsernameInput(props: { playerId: Players["id"]; username: string }) {
             variant="outlined"
             size="small"
             defaultValue={props.username || ""}
+			// Added to prevent usernames longer than 20 characters, 
+			// because many people play on mobile devices and you have to scroll with longer names.
+			inputProps={{ maxLength: 20 }}
             onChange={({ target: { value } }) => {
               setValue(value)
             }}

--- a/app/src/pages/Lobby/Inputs/UsernameInput.tsx
+++ b/app/src/pages/Lobby/Inputs/UsernameInput.tsx
@@ -31,9 +31,9 @@ function UsernameInput(props: { playerId: Players["id"]; username: string }) {
             variant="outlined"
             size="small"
             defaultValue={props.username || ""}
-			// Added to prevent usernames longer than 20 characters, 
-			// because many people play on mobile devices and you have to scroll with longer names.
-			inputProps={{ maxLength: 20 }}
+			      // Added to prevent usernames longer than 20 characters, 
+			      // because many people play on mobile devices and you have to scroll with longer names.
+			      inputProps={{ maxLength: 20 }}
             onChange={({ target: { value } }) => {
               setValue(value)
             }}


### PR DESCRIPTION
# UsernameInput: Set maximum username length to 20

This Pull Request sets the maximum username input field to 20 characters. 

This is to prevent having to scroll very far on mobile devices, so nobody can ruin the game for a team.

## Current:
<img width="906" alt="Screen Shot 2022-04-23 at 7 48 46 PM" src="https://user-images.githubusercontent.com/49456798/164949787-f53116b4-ad07-40b8-9424-8160cae37d87.png">

## New:
![Screen_Recording_2022-04-23_at_7_46_24_PM_AdobeCreativeCloudExpress](https://user-images.githubusercontent.com/49456798/164949849-90e2571c-6e2a-43e6-8dd0-8c9dce9bc77c.gif)

Closes #143 